### PR TITLE
Add tvOS support

### DIFF
--- a/ios/RCTWebRTC/WebRTCModule.m
+++ b/ios/RCTWebRTC/WebRTCModule.m
@@ -59,11 +59,10 @@
         RTCSetMinDebugLogLevel(loggingSeverity);
 
         RTC_OBJC_TYPE(RTCAudioSessionConfiguration) *webRTCConfig = [RTC_OBJC_TYPE(RTCAudioSessionConfiguration) webRTCConfiguration];
-        // Configure Webrtc Audio Session to be recvOnly mode
-        if (audioRecvOnly) {
-          webRTCConfig.recvOnlyMode = true;
-        }
-        webRTCConfig.categoryOptions = AVAudioSessionCategoryOptionDefaultToSpeaker;
+        webRTCConfig.recvOnlyMode = audioRecvOnly;
+#if TARGET_OS_IOS
+    webRTCConfig.categoryOptions = AVAudioSessionCategoryOptionDefaultToSpeaker;
+#endif
         [RTC_OBJC_TYPE(RTCAudioSessionConfiguration) setWebRTCConfiguration:webRTCConfig];
 
         if (encoderFactory == nil) {

--- a/react-native-webrtc.podspec
+++ b/react-native-webrtc.podspec
@@ -21,5 +21,5 @@ Pod::Spec.new do |s|
   s.dependency          'React-Core'
 
   # Note: Need to be supplied by a private pod specs repo
-  s.dependency          'RNMillicastWebRTC', '~> 118.0.0'
+  s.dependency          'RNMillicastWebRTC', '118.0.0-4d27b948'
 end


### PR DESCRIPTION
Description

Limit categoryOptions only to platform iOS
Passthrough the recvOnlyMode flag to webrtc config